### PR TITLE
Jhnftz/small flow update

### DIFF
--- a/content/00_introduction/04_inline_scanning.md
+++ b/content/00_introduction/04_inline_scanning.md
@@ -1,6 +1,6 @@
 
 +++
-title = "Inline Scanning"
+title = "Image Scanning"
 chapter = false
 weight = 04
 +++

--- a/content/10_prerequisites/30_sysdig.md
+++ b/content/10_prerequisites/30_sysdig.md
@@ -23,14 +23,5 @@ You need a Sysdig Secure account to complete this workshop. In particular you wi
 
         **IMPORTANT:** Make sure you **DO NOT** use the **Sysdig Monitor** API Token, or the Access Token!
 
-3. Copy and run the following two commands into your Cloud9 Workspace console and follow the instructions to configure your __Secure API Token__ and  __Secure API Endpoint__ as environment variables.
-
-```sh
-echo "Enter your 'Sysdig Secure API Token' from above"; read SecureAPIToken 
-```
-
-```sh
-echo "Enter your 'Sysdig Secure API Endpoint' from above"; read SecureEndpoint
-```
 
 <img src=/images/10_prerequisites/apiValues.gif width="100%" >

--- a/content/40_module_2/41_deploy_image_scanner_for_fargate.md
+++ b/content/40_module_2/41_deploy_image_scanner_for_fargate.md
@@ -8,17 +8,37 @@ To deploy the Sysdig image scanner for Fargate, we'll again use Amazon CloudForm
 
 ***Note*** You can find instructions on using the CLI on the [[Sysdig Fargate scanning installation page](https://sysdiglabs.github.io/ecs-image-scanning/install.html)](https://sysdiglabs.github.io/ecs-image-scanning/install.html)
 
+<!--
+1. Copy and run the following two commands into your Cloud9 Workspace console and follow the instructions to configure your __Secure API Token__ and  __Secure API Endpoint__ as environment variables.
 
-1. First, make sure your Sysdig `SecureAPIToken` and `SecureEndpoint` environment variables are set.
+```sh
+echo "Enter your 'Sysdig Secure API Token' from above"; read SecureAPIToken 
+```
+
+```sh
+echo "Enter your 'Sysdig Secure API Endpoint' from above"; read SecureEndpoint
+```
+ -->
+
+
+ 1. Configure your __Secure API Token__ and  __Secure API Endpoint__ as environment variables.
+
+ ```sh
+ SecureAPIToken =<<YOUR_API_TOKEN>>
+ ```
+
+ ```sh
+ SecureEndpoint=<YOUR_API_ENDPOINT>
+ ```
+
+    You should have made a note of these environment variables when setting up your [Cloud9 Workspace]({{< ref "/10_prerequisites/15_workspace_setup/23_cloud.md" >}}).
+
+    Make sure your Sysdig `SecureAPIToken` and `SecureEndpoint` environment variables are set correctly.
 
     ```
     echo $SecureAPIToken
     echo $SecureEndpoint
     ```
-
-    You should have set these environment variables when setting up your [Cloud9 Workspace]({{< ref "/10_prerequisites/15_workspace_setup/23_cloud.md" >}}).
-
-    **IMPORTANT** If these variable are not set, then you can set them manually using the information you noted from [here]({{< ref "/10_prerequisites/30_sysdig.md" >}}).
 
 1. Let's set our CloudFormation template URL as an environment variable to simplify the actual `aws` command.  
 

--- a/content/40_module_2/41_deploy_image_scanner_for_fargate.md
+++ b/content/40_module_2/41_deploy_image_scanner_for_fargate.md
@@ -24,7 +24,7 @@ echo "Enter your 'Sysdig Secure API Endpoint' from above"; read SecureEndpoint
  1. Configure your __Secure API Token__ and  __Secure API Endpoint__ as environment variables.
 
  ```sh
- SecureAPIToken =<<YOUR_API_TOKEN>>
+ SecureAPIToken =<YOUR_API_TOKEN>
  ```
 
  ```sh


### PR DESCRIPTION
*Issue #, if available:*
It can take several minutes for Sysdig trial email to arrive, so there would be a delay right at the start of the workshop as they set up their account before they can set the 'SecureAPIToken ' & 'SecureEndpoint' env variables.  


*Description of changes:*
Moved setting these env vars out of prerequisites and into 'Deploy Sysdig Secure Automatic Image Scanner for Fargate' where they're used. 

Also renamed 'Inline Scanning' to 'Image Scanning', as it also covers 'Backend Scanning'


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
